### PR TITLE
fix: update image to one which exists in the registry

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     #  - HOST=0.0.0.0
     #  - INSECURE=false
 
-    image: ghcr.io/wg-easy/wg-easy:15
+    image: ghcr.io/wg-easy/wg-easy:15.0.0-beta.12
     container_name: wg-easy
     networks:
       wg:


### PR DESCRIPTION
## Description
version 15 does not exist in the registry
15.0.0-beta.12 does, however

## Motivation and Context
pulling from the master branch and executing docker compose with the non dev file should not result in an error
https://github.com/wg-easy/wg-easy/issues/1820

## How has this been tested?
changed referenced image tag
ran docker compose
proxmox vm ubuntu 24.04 fresh install with docker
git clone wg-easy
docker compose what's up -dawg ??? profit
<!--- your change affects other areas of the code, etc. -->
no

## Screenshots (if appropriate):
---

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [✅ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [✅ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
